### PR TITLE
Add env var options on chart templates

### DIFF
--- a/helm/hocs-cms-data-migrator/templates/_envs.tpl
+++ b/helm/hocs-cms-data-migrator/templates/_envs.tpl
@@ -99,23 +99,23 @@
       name: {{ .Release.Namespace }}-case-migrator-sqs
       key: sqs_url
 - name: SEND_MIGRATION_MESSAGE
-  value: 'disabled'
+  value: '{{ .Values.sendMigrationMessage | default "disabled" }}'
 - name: MIGRATION_DOCUMENT
-  value: 'enabled'
+  value: '{{ .Values.migrationDocument | default "enabled" }}'
 - name: CMS_EXTRACT_COMPLAINTS
-  value: 'enabled'
+  value: 'disabled'
 - name: COMPLAINT_START_DATE
-  value: '2022-01-08'
+  value: '{{ .Values.complaintsStartDate | default "2022-01-08" }}'
 - name: COMPLAINT_END_DATE
-  value: '2022-03-31'
+  value: '{{ .Values.complaintsEndDate | default "2022-03-31" }}'
 - name: CMS_EXTRACT_SELECTED_COMPLAINTS
-  value: 'disabled'
+  value: '{{ .Values.extractSelectedComplaints | default "disabled" }}'
 - name: COMPLAINT_IDS
-  value: '131000000515|131000342867|131000342197|131000347033'
+  value: '{{ .Values.selectedComplaintIds | default "131000000515|131000342867|131000342197|131000347033" }}'
 - name: CMS_EXTRACT_OPEN_COMPLAINTS
-  value: 'disabled'
+  value: '{{ .Values.extractOpenComplaints | default "disabled" }}'
 - name: CMS_EXTRACT_CLOSED_COMPLAINTS
-  value: 'disabled'
+  value: '{{ .Values.extractClosedComplaints | default "disabled" }}'
 - name: CMS_EXTRACT_TREAT_OFFICIAL_CLOSED_CASES
   value: 'disabled'
 - name: TREAT_OFFICIAL_CASE_START_DATE

--- a/helm/hocs-cms-data-migrator/templates/job.yaml
+++ b/helm/hocs-cms-data-migrator/templates/job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: extract-cms-data
+  name: '{{ .Values.jobName | default "extract-cms-data" }}'
   labels:
     version: {{ .Values.version }}
 spec:


### PR DESCRIPTION
Allow settings within envs.tpl and job name to be overridden by environment variables